### PR TITLE
Hide data model and export interface

### DIFF
--- a/transcription_initiation_polII.html
+++ b/transcription_initiation_polII.html
@@ -457,6 +457,13 @@
       background: transparent;
       border: 2px dashed rgba(29, 78, 216, 0.7);
     }
+
+    .data-model,
+    footer,
+    #reference-overlay,
+    #import-file {
+      display: none !important;
+    }
     .visually-hidden {
       position: absolute !important;
       width: 1px;


### PR DESCRIPTION
## Summary
- hide the data model block along with the footer export controls and reference overlay

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dae16d5a4083258dee120a83559eaf